### PR TITLE
Add viral video experiment instrument

### DIFF
--- a/instruments/default/viral_video_experiment/viral_video_experiment.md
+++ b/instruments/default/viral_video_experiment/viral_video_experiment.md
@@ -1,0 +1,18 @@
+# Problem
+Run a small viral video experiment by downloading trending clips, adding branding and a CTA, and logging processed files.
+
+# Solution
+1. If a working folder is required, `cd` to it.
+2. Run the shell script with your query, number of clips, branding text, and CTA text:
+
+```bash
+bash /a0/instruments/default/viral_video_experiment/viral_video_experiment.sh "<query>" <count> "<branding>" "<cta>"
+```
+
+Example:
+
+```bash
+bash /a0/instruments/default/viral_video_experiment/viral_video_experiment.sh "morning routines" 5 "MyBrand" "Visit example.com"
+```
+
+3. Processed videos are stored in `tmp/viral_videos/processed` and a CSV log is written to `tmp/viral_videos/experiment_metrics.csv`.

--- a/instruments/default/viral_video_experiment/viral_video_experiment.py
+++ b/instruments/default/viral_video_experiment/viral_video_experiment.py
@@ -1,0 +1,79 @@
+import argparse
+import csv
+import subprocess
+from pathlib import Path
+
+
+def download_videos(query: str, count: int, output_dir: Path) -> None:
+    """Download `count` videos matching `query` into `output_dir` using yt-dlp."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    search_term = f"ytsearch{count}:{query}"
+    cmd = [
+        "yt-dlp",
+        search_term,
+        "-o",
+        str(output_dir / "%(id)s.%(ext)s"),
+        "--format",
+        "mp4",
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def brand_video(source: Path, branding: str, cta: str, output_dir: Path) -> Path:
+    """Add simple text overlays for branding and CTA using ffmpeg."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target = output_dir / f"{source.stem}_branded.mp4"
+    drawtext = (
+        f"drawtext=text='{branding}':x=10:y=h-th-10:fontcolor=white:fontsize=24:"
+        f"box=1:boxcolor=black@0.5,"
+        f"drawtext=text='{cta}':x=w-tw-10:y=h-th-10:fontcolor=white:fontsize=24:"
+        "box=1:boxcolor=black@0.5"
+    )
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(source),
+        "-vf",
+        drawtext,
+        "-c:a",
+        "copy",
+        str(target),
+    ]
+    subprocess.run(cmd, check=True)
+    return target
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a viral video experiment")
+    parser.add_argument("query", help="Search term for trending clips")
+    parser.add_argument("count", type=int, help="Number of clips to download")
+    parser.add_argument("branding", help="Branding text to overlay")
+    parser.add_argument("cta", help="CTA text or link to overlay")
+    parser.add_argument(
+        "--workdir",
+        default="tmp/viral_videos",
+        help="Directory to store downloads and processed clips",
+    )
+    args = parser.parse_args()
+
+    workdir = Path(args.workdir)
+    downloads = workdir / "downloads"
+    processed = workdir / "processed"
+
+    download_videos(args.query, args.count, downloads)
+
+    csv_path = workdir / "experiment_metrics.csv"
+    with csv_path.open("w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["original_path", "processed_path"])
+        for video in downloads.glob("*.mp4"):
+            branded = brand_video(video, args.branding, args.cta, processed)
+            writer.writerow([video, branded])
+
+    print(f"Processed videos saved to {processed}")
+    print(f"Metrics CSV written to {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/instruments/default/viral_video_experiment/viral_video_experiment.sh
+++ b/instruments/default/viral_video_experiment/viral_video_experiment.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR=$(dirname "$0")
+python3 "$SCRIPT_DIR/viral_video_experiment.py" "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ unstructured==0.15.13
 unstructured-client==0.25.9
 webcolors==24.6.0
 crontab==1.0.1
+yt-dlp==2025.7.21


### PR DESCRIPTION
## Summary
- Add instrument to download and brand trending clips for a small viral video experiment
- Log processed video paths to CSV and document usage
- Pin yt-dlp dependency

## Testing
- `python instruments/default/viral_video_experiment/viral_video_experiment.py --help`
- `bash instruments/default/viral_video_experiment/viral_video_experiment.sh "test" 1 "Brand" "cta.com"` *(fails: Unable to connect to proxy)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f7b589da4832198437593c94e410a